### PR TITLE
Fix version conflicts caused by PR#57

### DIFF
--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/ReactiveMarbles.ObservableEvents.SourceGenerator.csproj
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/ReactiveMarbles.ObservableEvents.SourceGenerator.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.CodeAnalysis.CSharp.Workspaces from 3.8.0 to 3.10.0.[(PR#57)](https://github.com/reactivemarbles/ObservableEvents/pull/57).
Hope this fix can help you.

Best regards,
sucrose
