### PR TITLE
Enable asyncronous event observables to be generated

### DIFF
--- a/src/ReactiveMarbles.ObservableEvents.Example/MyForm.cs
+++ b/src/ReactiveMarbles.ObservableEvents.Example/MyForm.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Reactive;
-using System.Text;
+using System.Threading.Tasks;
 
 using ReactiveMarbles.ObservableEvents;
 
@@ -37,6 +35,18 @@ namespace ReactiveMarbles.ObservableEvents
         public MyNoEventsClass()
         {
             this.Events();
+        }
+    }
+
+    public class AsyncEventsClass
+    {
+        public event Func<int, Task> TestEvent1;
+        public event Func<int, ValueTask> TestEvent2;
+
+        public AsyncEventsClass()
+        {
+            var e1 = this.Events().TestEvent1;
+            var e2 = this.Events().TestEvent2;
         }
     }
 

--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerator.cs
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerator.cs
@@ -219,7 +219,7 @@ namespace ReactiveMarbles.ObservableEvents
 
                 processedItems.Add(item);
 
-                var namespaceItem = symbolGenerator.Generate(item);
+                var namespaceItem = symbolGenerator.Generate(item, context.Compilation.GetTypeByMetadataName);
 
                 if (namespaceItem == null)
                 {

--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/EventGeneratorBase.cs
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/EventGeneratorBase.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace ReactiveMarbles.ObservableEvents.SourceGenerator.EventGenerators.Gener
     internal abstract class EventGeneratorBase : IEventSymbolGenerator
     {
         /// <inheritdoc />
-        public abstract NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item);
+        public abstract NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item, Func<string, ITypeSymbol?> getSymbolOf);
 
         /// <summary>
         /// Generates an observable declaration that wraps a event.

--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/IEventSymbolGenerator.cs
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/IEventSymbolGenerator.cs
@@ -2,7 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
+using System;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -18,7 +18,8 @@ namespace ReactiveMarbles.ObservableEvents.SourceGenerator.EventGenerators.Gener
         /// Generates a compilation unit based on generating event observable wrappers.
         /// </summary>
         /// <param name="item">The symbol to generate for.</param>
+        /// <param name="getSymbolOf">Gets the symbol of a given type name.</param>
         /// <returns>The new compilation unit.</returns>
-        NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item);
+        NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item, Func<string, ITypeSymbol?> getSymbolOf);
     }
 }

--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/InstanceEventGenerator.cs
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/InstanceEventGenerator.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -20,15 +19,15 @@ namespace ReactiveMarbles.ObservableEvents.SourceGenerator.EventGenerators.Gener
         private const string DataFieldName = "_data";
 
         /// <inheritdoc />
-        public override NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item)
+        public override NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item, Func<string, ITypeSymbol?> getSymbolOf)
         {
             var namespaceName = item.ContainingNamespace.ToDisplayString(RoslynHelpers.SymbolDisplayFormat);
 
-            var eventWrapperes = GenerateEventWrapperClasses(item, item.GetEvents().ToArray()).ToList();
+            var eventWrapperes = GenerateEventWrapperClasses(item, item.GetEvents(getSymbolOf).ToArray()).ToList();
 
             if (eventWrapperes.Count > 0)
             {
-               return NamespaceDeclaration(namespaceName, eventWrapperes, true);
+                return NamespaceDeclaration(namespaceName, eventWrapperes, true);
             }
 
             return null;

--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/StaticEventGenerator.cs
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/EventGenerators/Generators/StaticEventGenerator.cs
@@ -17,13 +17,13 @@ namespace ReactiveMarbles.ObservableEvents.SourceGenerator.EventGenerators.Gener
     internal class StaticEventGenerator : EventGeneratorBase
     {
         /// <inheritdoc />
-        public override NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item)
+        public override NamespaceDeclarationSyntax? Generate(INamedTypeSymbol item, Func<string, ITypeSymbol?> getSymbolOf)
         {
             var eventWrapperMembers = new List<PropertyDeclarationSyntax>();
 
             var namespaceName = item.ContainingNamespace.ToDisplayString(RoslynHelpers.SymbolDisplayFormat);
 
-            foreach (var eventDetail in item.GetEvents(true))
+            foreach (var eventDetail in item.GetEvents(getSymbolOf, true))
             {
                 var eventWrapper = GenerateEventWrapperObservable(eventDetail, item.GenerateFullGenericName(), item.Name);
 

--- a/src/ReactiveMarbles.ObservableEvents.SourceGenerator/SyntaxFactoryHelpers.cs
+++ b/src/ReactiveMarbles.ObservableEvents.SourceGenerator/SyntaxFactoryHelpers.cs
@@ -598,11 +598,11 @@ namespace ReactiveMarbles.ObservableEvents.SourceGenerator
         public static LocalDeclarationStatementSyntax LocalDeclarationStatement(VariableDeclarationSyntax declaration) => SyntaxFactory.LocalDeclarationStatement(default, default, default, default, declaration, Token(SyntaxKind.SemicolonToken));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static LocalFunctionStatementSyntax LocalFunctionStatement(string returnType, string functionName, IReadOnlyCollection<ParameterSyntax>? parameters, ArrowExpressionClauseSyntax expressionBody)
+        public static LocalFunctionStatementSyntax LocalFunctionStatement(string returnType, string functionName, IReadOnlyCollection<ParameterSyntax>? parameters, ArrowExpressionClauseSyntax? expressionBody = default, BlockSyntax? blockSyntax = default)
         {
             var parameterList = ParameterList(parameters);
 
-            return SyntaxFactory.LocalFunctionStatement(default, default, IdentifierName(returnType).AddTrialingSpaces(), Identifier(functionName), default, parameterList, default, default, expressionBody, Token(SyntaxKind.SemicolonToken));
+            return SyntaxFactory.LocalFunctionStatement(default, default, IdentifierName(returnType).AddTrialingSpaces(), Identifier(functionName), default, parameterList, default, blockSyntax, expressionBody, Token(SyntaxKind.SemicolonToken));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This PR enables the generation of observables from asyncronous events.
This is done by enabling the analyzer to return events with the returnType of "Task" and "ValueTask" 
and enabling the generators to generate appropriate handlers using "Task.CompletedTask" and default(ValueTask)" as return tasks.